### PR TITLE
possible layout refactor

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,14 +10,17 @@ import Help from './pages/Help';
 import New_Proposal from './pages/New_Proposal';
 import New_Grant from './pages/New_Grant';
 import View_Proposal from './pages/View_Proposal';
+import Layout from './Layout';
 
 function App() {
   return (
     <Router>
       <Routes>
-        <Route exact path='/' element={<Dashboard/>}></Route>
-        <Route path='/proposals' element={<Proposals/>}></Route>
-        <Route path='/grants' element={<Grants/>}></Route>
+        <Route element={<Layout />}>
+            <Route exact path='/' element={<Dashboard/>}></Route>
+            <Route path='/proposals' element={<Proposals/>}></Route>
+            <Route path='/grants' element={<Grants/>}></Route>
+        </Route>
         <Route path='/help' element={<Help/>}></Route>
         <Route path='/new_proposal' element={<New_Proposal/>}></Route>
         <Route path='/new_grant' element={<New_Grant/>}></Route>

--- a/src/Layout.jsx
+++ b/src/Layout.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Outlet } from 'react-router';
+
+function Layout() {
+    return (
+        <div>
+            {/* <Navbar /> */}
+            <Outlet />
+        </div>
+    )
+}
+
+export default Layout;


### PR DESCRIPTION
Just reviewed the frontend revamp. I think most refactoring will come after we figure out the state issue but a couple suggestions. First, the main thing that code in this PR actually addresses. I noticed that the 3 main pages: Dashboard, grants, proposals, all have the same general layout. There is some duplicate html code in each component, and I think this could all be extracted to a generic "layout" component. The differences would be rendered in `<Outlet />`. See this for more: https://reactrouter.com/docs/en/v6/getting-started/concepts#layout-routes

Other than that, some possible suggestions:
- dashboard is at `/` right now, but the root will probably have to be the landing page. Can the landing page be just done in the `index.html` file? Since it will literally just be text and images.
- I noticed there is a single path `/view_proposal` that renders the specific view for a proposal/grant. This works for now since each dummy proposal is the exact same. But once we have real proposals, each proposal will be different. So we might need something like url params: https://reactrouter.com/docs/en/v6/getting-started/concepts#match-params. Just something to think about, might be hard to reason about since state isn't set yet.
- be on the lookout for things that can be made into components. This might be hard to do tho since we don't exactly know how the state management will work

This PR doesn't have to be merged. Just easiest way to make a comment.
